### PR TITLE
Opening overlay on pressing search button

### DIFF
--- a/lib/easy_search_bar.dart
+++ b/lib/easy_search_bar.dart
@@ -426,6 +426,7 @@ class _EasySearchBarState extends State<EasySearchBar> with TickerProviderStateM
                                           onPressed: () {
                                             _controller.forward();
                                             _focusNode.requestFocus();
+                                            openOverlay();
                                           },
                                           tooltip: MaterialLocalizations.of(context).searchFieldLabel
                                         )


### PR DESCRIPTION
I have a project where I use this package, but a client was kinda annoyed that when you close the search widget and open again the suggestions doesn't appear immediately.
It is a silly thing, but I think it adds some value to the package.